### PR TITLE
Add loading feedback to lunch lookup

### DIFF
--- a/functions/main.py
+++ b/functions/main.py
@@ -1,13 +1,12 @@
 """Firebase Cloud Functions for Lunch Menu Generator"""
 
 import os
-import json
 from datetime import datetime, timedelta
-from typing import Dict, Any
+from typing import Dict
 
 import firebase_admin
 from firebase_admin import credentials, firestore, storage
-from flask import Request, jsonify
+from flask import Request, jsonify, make_response, Response
 import functions_framework
 
 from menu_generator.scraper import MenuScraper
@@ -42,84 +41,92 @@ def get_week_identifier(weeks_offset: int = 0) -> str:
 
 def cors_enabled(func):
     """Decorator to enable CORS for Cloud Functions"""
+
     def wrapper(request: Request):
-        # Handle preflight OPTIONS request
-        if request.method == 'OPTIONS':
-            headers = {
-                'Access-Control-Allow-Origin': '*',
-                'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
-                'Access-Control-Allow-Headers': 'Content-Type',
-                'Access-Control-Max-Age': '3600'
-            }
-            return ('', 204, headers)
-        
-        # Set CORS headers for main request
-        headers = {
-            'Access-Control-Allow-Origin': '*'
+        cors_headers = {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+            'Access-Control-Allow-Headers': 'Content-Type',
+            'Access-Control-Max-Age': '3600'
         }
-        
+
+        if request.method == 'OPTIONS':
+            response = make_response('', 204)
+            response.headers.update(cors_headers)
+            return response
+
         try:
             result = func(request)
-            return (result, 200, headers)
-        except Exception as e:
-            error_response = jsonify({'error': str(e)})
-            return (error_response, 500, headers)
-    
+        except Exception as exc:  # pragma: no cover - defensive programming
+            result = (jsonify({'error': str(exc)}), 500)
+
+        extra_headers: Dict[str, str] = {}
+
+        if isinstance(result, tuple):
+            body = result[0]
+            status = result[1] if len(result) > 1 else 200
+            extra_headers = result[2] if len(result) > 2 else {}
+
+            if isinstance(body, Response):
+                response = body
+                response.status_code = status
+            else:
+                response = make_response(body, status)
+        else:
+            response = result if isinstance(result, Response) else make_response(result, 200)
+
+        response.headers.update(cors_headers)
+        response.headers.update(extra_headers)
+        return response
+
     return wrapper
 
 
 @functions_framework.http
 @cors_enabled
 def scrape_menu(request: Request):
-    """
-    Scrape menu data from a URL
-    
-    Request body:
-    {
-        "url": "https://school.com/menu",
-        "week_offset": 0
-    }
-    """
-    data = request.get_json()
+    """Scrape menu data from a URL and return today's menu item."""
+
+    data = request.get_json(silent=True) or {}
     url = data.get('url')
-    week_offset = data.get('week_offset', 0)
-    
+
     if not url:
         return jsonify({'error': 'URL is required'}), 400
-    
+
+    # Determine today's weekday identifier
+    today = datetime.now()
+    today_key = today.strftime('%A').lower()
+
     try:
-        # Initialize scraper
         scraper = MenuScraper(CONFIG['firecrawl_api_key'])
-        
-        # Scrape menu
-        week_id = get_week_identifier(week_offset)
         menu_data = scraper.scrape_with_nutrition(url)
-        
+
         if not menu_data:
-            return jsonify({'error': 'Failed to scrape menu'}), 500
-        
-        # Parse into MenuItem objects
-        menu_items = scraper.parse_menu_data(menu_data, week_offset)
-        
-        # Cache in Firestore
-        cache_ref = db.collection('menu_cache').document(f"{week_id}_{hash(url)}")
+            return jsonify({'error': 'Failed to scrape menu'}), 502
+
+        menu_items = scraper.parse_menu_data(menu_data, 0)
+        today_item = menu_items.get(today_key)
+
+        if not today_item:
+            error_message = f'No menu information found for {today.strftime("%A")}'
+            return jsonify({'error': error_message}), 404
+
+        # Cache today's result for quick access later
+        cache_ref = db.collection('menu_cache').document(f"{today_key}_{today.strftime('%Y%m%d')}_{hash(url)}")
         cache_ref.set({
             'url': url,
-            'week_id': week_id,
-            'menu_data': {day: item.to_dict() for day, item in menu_items.items()},
+            'day': today_key,
+            'date': today_item.date,
+            'menu_item': today_item.to_dict(),
             'timestamp': firestore.SERVER_TIMESTAMP
         })
-        
-        # Get week info
-        week_dates = scraper.get_week_dates(week_offset)
-        monday_date = list(week_dates.values())[0]
-        
+
         return jsonify({
-            'menu_data': {day: item.to_dict() for day, item in menu_items.items()},
-            'week_id': week_id,
-            'week_info': monday_date
+            'menu_item': today_item.to_dict(),
+            'day': today_key,
+            'date': today_item.date
         })
-        
+
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
@@ -136,10 +143,10 @@ def generate_calendar(request: Request):
         "week_id": "2024-W42"
     }
     """
-    data = request.get_json()
+    data = request.get_json(silent=True) or {}
     menu_data = data.get('menu_data')
     week_id = data.get('week_id')
-    
+
     if not menu_data or not week_id:
         return jsonify({'error': 'menu_data and week_id are required'}), 400
     
@@ -201,7 +208,7 @@ def export_pdf(request: Request):
         "week_id": "2024-W42"
     }
     """
-    data = request.get_json()
+    data = request.get_json(silent=True) or {}
     menu_data = data.get('menu_data')
     week_id = data.get('week_id')
     
@@ -246,7 +253,7 @@ def send_email(request: Request):
         "week_id": "2024-W42"
     }
     """
-    data = request.get_json()
+    data = request.get_json(silent=True) or {}
     recipient = data.get('recipient')
     calendar_url = data.get('calendar_url')
     pdf_url = data.get('pdf_url')

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -143,6 +143,12 @@ body {
   margin-bottom: var(--spacing-md);
 }
 
+.helper-text {
+  margin-top: var(--spacing-sm);
+  color: var(--secondary);
+  font-size: 0.95rem;
+}
+
 label {
   display: block;
   font-weight: 600;
@@ -169,6 +175,7 @@ label {
 .btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--spacing-xs);
   padding: var(--spacing-sm) var(--spacing-lg);
   border: none;
@@ -178,6 +185,33 @@ label {
   cursor: pointer;
   transition: all 0.3s;
   text-decoration: none;
+  position: relative;
+}
+
+.btn[disabled],
+.btn.is-loading {
+  cursor: not-allowed;
+  opacity: 0.85;
+}
+
+.btn-spinner {
+  display: inline-block;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 3px solid rgba(255, 255, 255, 0.4);
+  border-top-color: var(--white);
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+}
+
+.btn.is-loading .btn-icon,
+.btn.is-loading .btn-label {
+  opacity: 0;
+  transform: translateY(2px);
+}
+
+.btn.is-loading .btn-spinner {
+  display: inline-block;
 }
 
 .btn-primary {

--- a/public/index.html
+++ b/public/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>🍽️ Lunch Menu Generator - AI-Powered School Meals</title>
-    <meta name="description" content="Generate beautiful weekly lunch menus with AI-powered food images, nutrition tracking, and allergen information.">
+    <title>🍽️ Lunch Menu Finder - Today's School Lunch</title>
+    <meta name="description" content="Quickly look up today's school lunch menu, nutrition facts, and allergen information.">
     
     <!-- Favicon -->
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🍽️</text></svg>">
@@ -12,10 +12,6 @@
     <!-- CSS -->
     <link rel="stylesheet" href="/css/styles.css">
     
-    <!-- Firebase SDKs -->
-    <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-app-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-firestore-compat.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/10.7.1/firebase-storage-compat.js"></script>
 </head>
 <body>
     <!-- Header -->
@@ -26,7 +22,7 @@
                     <span class="logo-icon">🍽️</span>
                     Lunch Menu Generator
                 </h1>
-                <p class="tagline">AI-powered school meal planning with nutrition tracking</p>
+                <p class="tagline">Instantly check today's school lunch with nutrition details</p>
             </div>
         </div>
     </header>
@@ -35,97 +31,49 @@
     <main class="main-content">
         <div class="container">
             
-            <!-- Step 1: URL Input -->
-            <section class="card" id="step-url">
+            <!-- Search Input -->
+            <section class="card" id="step-search">
                 <div class="card-header">
-                    <h2>🔗 Step 1: Enter Menu URL</h2>
-                    <p>Provide the link to your school's lunch menu page</p>
+                    <h2>🔍 Find Today's Lunch Menu</h2>
+                    <p>Enter the link to your school's lunch menu to see what's for lunch today.</p>
                 </div>
                 <div class="card-body">
                     <div class="form-group">
                         <label for="menu-url">School Menu URL</label>
-                        <input 
-                            type="url" 
-                            id="menu-url" 
+                        <input
+                            type="url"
+                            id="menu-url"
                             class="input-field"
                             placeholder="https://school.com/lunch-menu"
                             required
                         >
                     </div>
-                    
-                    <div class="form-group">
-                        <label for="week-offset">Select Week</label>
-                        <select id="week-offset" class="input-field">
-                            <option value="-1">Last Week</option>
-                            <option value="0" selected>This Week</option>
-                            <option value="1">Next Week</option>
-                        </select>
-                    </div>
-                    
-                    <button id="btn-scrape" class="btn btn-primary btn-large">
-                        <span class="btn-icon">🔍</span>
-                        Scrape Menu
+
+                    <button
+                        id="btn-search"
+                        class="btn btn-primary btn-large"
+                        data-default-label="Find Today's Menu"
+                        data-loading-label="Fetching..."
+                    >
+                        <span class="btn-icon" aria-hidden="true">🍽️</span>
+                        <span class="btn-label">Find Today's Menu</span>
+                        <span class="btn-spinner hidden" aria-hidden="true"></span>
                     </button>
+
+                    <p id="today-label" class="helper-text"></p>
                 </div>
             </section>
 
-            <!-- Step 2: Menu Preview -->
-            <section class="card hidden" id="step-menu">
+            <!-- Today's Menu Result -->
+            <section class="card hidden" id="today-menu">
                 <div class="card-header">
-                    <h2>📋 Step 2: Review Menu</h2>
-                    <p id="menu-week-info">Week of ...</p>
+                    <h2>📋 Today's Lunch</h2>
+                    <p id="menu-date">&nbsp;</p>
                 </div>
                 <div class="card-body">
-                    <div id="menu-preview" class="menu-preview">
-                        <!-- Menu items will be inserted here -->
+                    <div id="menu-details" class="menu-preview">
+                        <!-- Menu details inserted here -->
                     </div>
-                    
-                    <div class="button-group">
-                        <button id="btn-edit-menu" class="btn btn-secondary">
-                            <span class="btn-icon">✏️</span>
-                            Edit Menu
-                        </button>
-                        <button id="btn-generate" class="btn btn-primary btn-large">
-                            <span class="btn-icon">🎨</span>
-                            Generate Calendar
-                        </button>
-                    </div>
-                </div>
-            </section>
-
-            <!-- Step 3: Calendar Result -->
-            <section class="card hidden" id="step-result">
-                <div class="card-header">
-                    <h2>✨ Your Weekly Menu Calendar</h2>
-                    <p>Generated successfully!</p>
-                </div>
-                <div class="card-body">
-                    <div id="calendar-preview" class="calendar-container">
-                        <img id="calendar-image" alt="Weekly Menu Calendar" />
-                    </div>
-                    
-                    <div class="export-options">
-                        <h3>Export Options</h3>
-                        <div class="button-group">
-                            <button id="btn-download-png" class="btn btn-secondary">
-                                <span class="btn-icon">🖼️</span>
-                                Download PNG
-                            </button>
-                            <button id="btn-download-pdf" class="btn btn-secondary">
-                                <span class="btn-icon">📄</span>
-                                Download PDF
-                            </button>
-                            <button id="btn-email" class="btn btn-secondary">
-                                <span class="btn-icon">📧</span>
-                                Email Menu
-                            </button>
-                        </div>
-                    </div>
-                    
-                    <button id="btn-new-menu" class="btn btn-primary">
-                        <span class="btn-icon">🆕</span>
-                        Create New Menu
-                    </button>
                 </div>
             </section>
 
@@ -133,32 +81,6 @@
             <div id="loading-overlay" class="loading-overlay hidden">
                 <div class="loading-spinner"></div>
                 <p id="loading-text" class="loading-text">Processing...</p>
-            </div>
-
-            <!-- Email Modal -->
-            <div id="email-modal" class="modal hidden">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h3>📧 Email Menu</h3>
-                        <button class="modal-close" onclick="closeEmailModal()">×</button>
-                    </div>
-                    <div class="modal-body">
-                        <div class="form-group">
-                            <label for="recipient-email">Recipient Email</label>
-                            <input 
-                                type="email" 
-                                id="recipient-email" 
-                                class="input-field"
-                                placeholder="parent@email.com"
-                                required
-                            >
-                        </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button class="btn btn-secondary" onclick="closeEmailModal()">Cancel</button>
-                        <button id="btn-send-email" class="btn btn-primary">Send Email</button>
-                    </div>
-                </div>
             </div>
 
         </div>


### PR DESCRIPTION
## Summary
- streamline the frontend into a single search flow that fetches only today's lunch menu
- harden the client API helper against invalid JSON and expose refreshed helper messaging
- update the scrape cloud function to return the current day's item and improve CORS/error handling
- add a loading state and spinner to the lunch lookup button so users see progress feedback while scraping

## Testing
- python -m compileall functions

------
https://chatgpt.com/codex/tasks/task_e_68e5777131e0832d85bc9cd70bf31110